### PR TITLE
Fix Three.js module resolution for starfield scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,14 +85,13 @@
     <p>© <span id="current-year"></span> Hao Jin. Crafted with curiosity and stardust.</p>
   </footer>
 
-  <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js" crossorigin="anonymous"></script>
-  <script type="module">
-    import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js';
-
-    if (window.THREE) {
-      window.THREE.OrbitControls = OrbitControls;
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js"
+      }
     }
   </script>
-  <script defer src="/js/starfield.js"></script>
+  <script type="module" src="/js/starfield.js"></script>
 </body>
 </html>

--- a/js/starfield.js
+++ b/js/starfield.js
@@ -1,8 +1,11 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+
 (function () {
   const canvas = document.getElementById('space-canvas');
   const heroSection = document.querySelector('.hero');
 
-  if (!canvas || !heroSection || typeof THREE === 'undefined' || typeof THREE.OrbitControls === 'undefined') {
+  if (!canvas || !heroSection) {
     return;
   }
 
@@ -19,7 +22,7 @@
   const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 1000);
   camera.position.set(0, 18, 140);
 
-  const controls = new THREE.OrbitControls(camera, canvas);
+  const controls = new OrbitControls(camera, canvas);
   controls.enableDamping = true;
   controls.enablePan = true;
   controls.minDistance = 30;


### PR DESCRIPTION
## Summary
- load three.js via an import map and run the starfield script as an ES module
- import OrbitControls directly within the module to restore interactive controls

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e236fcdf08832085170cd3b877bfd9