### PR TITLE
Add responsive mobile navigation for home page

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -504,11 +504,72 @@ body.home-page a:focus {
   display: flex;
   gap: 24px;
   font-size: 0.95rem;
+  z-index: 6;
 }
 
 .home-nav a {
   font-weight: 500;
   letter-spacing: 0.04em;
+}
+
+.nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  margin-left: 18px;
+  border: 1px solid rgba(191, 214, 255, 0.25);
+  border-radius: 999px;
+  background: rgba(4, 6, 18, 0.6);
+  color: inherit;
+  cursor: pointer;
+  position: relative;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.nav-toggle span,
+.nav-toggle::before,
+.nav-toggle::after {
+  content: '';
+  position: absolute;
+  left: 24%;
+  right: 24%;
+  height: 2px;
+  background: #f5f7ff;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav-toggle span {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.nav-toggle::before {
+  top: 34%;
+}
+
+.nav-toggle::after {
+  top: 66%;
+}
+
+.nav-toggle:hover,
+.nav-toggle:focus {
+  background: rgba(4, 6, 18, 0.8);
+  border-color: rgba(191, 214, 255, 0.45);
+  outline: none;
+}
+
+.nav-toggle[aria-expanded="true"]::before {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.nav-toggle[aria-expanded="true"] span {
+  opacity: 0;
+}
+
+.nav-toggle[aria-expanded="true"]::after {
+  transform: translateY(-6px) rotate(-45deg);
 }
 
 .hero {
@@ -570,7 +631,9 @@ body.home-page a:focus {
 }
 
 .cta {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 14px 36px;
   border-radius: 999px;
   background: linear-gradient(135deg, #5c8cff 0%, #889dff 100%);
@@ -743,14 +806,45 @@ body.home-page a:focus {
 
 @media (max-width: 640px) {
   .home-header {
-    flex-direction: column;
-    gap: 12px;
-    align-items: flex-start;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0;
   }
 
-  .home-nav {
-    flex-wrap: wrap;
-    gap: 12px 16px;
+  body.nav-enhanced .home-nav {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+    padding: 0 6vw;
+    max-height: 0;
+    overflow: hidden;
+    background: rgba(4, 6, 18, 0.95);
+    border-bottom: 1px solid rgba(120, 147, 255, 0.15);
+    box-shadow: 0 16px 30px rgba(6, 10, 31, 0.35);
+    transition: max-height 0.3s ease, padding 0.3s ease;
+  }
+
+  body.nav-enhanced .home-nav a {
+    width: 100%;
+    padding: 12px 0;
+    border-bottom: 1px solid rgba(120, 147, 255, 0.12);
+  }
+
+  body.nav-enhanced .home-nav a:last-child {
+    border-bottom: none;
+  }
+
+  body.nav-enhanced .home-nav.is-open {
+    padding: 12px 6vw 20px;
+    max-height: 320px;
+  }
+
+  body.nav-enhanced .nav-toggle {
+    display: inline-flex;
   }
 
   .hero {
@@ -768,5 +862,52 @@ body.home-page a:focus {
 
   .profile {
     padding: 80px 6vw;
+  }
+}
+
+@media (max-width: 480px) {
+  .home-header {
+    padding: 18px 5vw;
+  }
+
+  .hero {
+    padding: 140px 5vw 80px;
+    align-items: flex-start;
+  }
+
+  .hero-overlay {
+    text-align: left;
+  }
+
+  .hero-overlay .tagline {
+    font-size: 0.85rem;
+    letter-spacing: 0.18em;
+  }
+
+  .hero-overlay p.lead {
+    font-size: 0.95rem;
+  }
+
+  .cta {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .profile {
+    padding: 72px 5vw;
+  }
+}
+
+@media (max-width: 360px) {
+  .hero-overlay h1 {
+    font-size: clamp(2rem, 10vw, 2.6rem);
+  }
+
+  .info-card {
+    padding: 22px;
+  }
+
+  body.nav-enhanced .home-nav.is-open {
+    padding-bottom: 16px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -16,12 +16,15 @@
 <body class="home-page">
   <header class="home-header">
     <div class="brand">Hao Jin</div>
-    <nav class="home-nav">
+    <nav class="home-nav" id="primary-navigation">
       <a href="#top">Home</a>
       <a href="#about">About</a>
       <a href="https://github.com/jhao" target="_blank" rel="noopener">GitHub</a>
       <a href="mailto:hao.jin@live.cn">Contact</a>
     </nav>
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Toggle navigation">
+      <span></span>
+    </button>
   </header>
 
   <main>
@@ -93,5 +96,6 @@
     }
   </script>
   <script type="module" src="/js/starfield.js"></script>
+  <script src="/js/home.js" defer></script>
 </body>
 </html>

--- a/js/home.js
+++ b/js/home.js
@@ -1,0 +1,50 @@
+(function () {
+  const header = document.querySelector('.home-header');
+  const nav = document.querySelector('.home-nav');
+  const toggle = document.querySelector('.nav-toggle');
+
+  const body = document.body;
+
+  if (!header || !nav || !toggle || !body) {
+    return;
+  }
+
+  body.classList.add('nav-enhanced');
+
+  const setExpandedState = (isOpen) => {
+    toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    nav.classList.toggle('is-open', isOpen);
+    nav.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+  };
+
+  const closeNav = () => setExpandedState(false);
+
+  setExpandedState(false);
+
+  if (window.innerWidth > 640) {
+    setExpandedState(true);
+  }
+
+  toggle.addEventListener('click', () => {
+    const willOpen = !nav.classList.contains('is-open');
+    setExpandedState(willOpen);
+  });
+
+  nav.addEventListener('click', (event) => {
+    if (
+      event.target instanceof HTMLElement &&
+      event.target.tagName === 'A' &&
+      window.innerWidth <= 640
+    ) {
+      closeNav();
+    }
+  });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 640) {
+      setExpandedState(true);
+    } else {
+      closeNav();
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add an accessible mobile navigation toggle for the home page header
- tweak hero and content spacing to better support small screen layouts
- introduce a lightweight script to progressively enhance navigation behavior

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e378cc5124832093ab17956ca417ca