### PR TITLE
Add multilingual toggle and update playground section

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -509,8 +509,18 @@ body.home-page a:focus {
   color: #ffffff;
 }
 
+.home-header .header-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 20px;
+  flex: 1 1 auto;
+  position: relative;
+}
+
 .home-nav {
   display: flex;
+  align-items: center;
   gap: 24px;
   font-size: 0.95rem;
   z-index: 6;
@@ -519,6 +529,49 @@ body.home-page a:focus {
 .home-nav a {
   font-weight: 500;
   letter-spacing: 0.04em;
+}
+
+.language-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid rgba(120, 147, 255, 0.25);
+  background: rgba(4, 6, 18, 0.65);
+  box-shadow: 0 12px 24px rgba(6, 10, 31, 0.28);
+  backdrop-filter: blur(6px);
+  flex-shrink: 0;
+}
+
+.language-button {
+  border: none;
+  background: transparent;
+  color: rgba(214, 223, 255, 0.86);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.language-button:hover,
+.language-button:focus {
+  color: #ffffff;
+}
+
+.language-button:focus-visible {
+  outline: 2px solid rgba(197, 210, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.language-button.is-active {
+  background: linear-gradient(135deg, rgba(98, 123, 255, 0.9), rgba(155, 185, 255, 0.9));
+  color: #050813;
+  box-shadow: 0 10px 20px rgba(6, 10, 31, 0.35);
 }
 
 .nav-toggle {
@@ -946,12 +999,13 @@ body.home-page a:focus {
 
 .playground-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 32px;
 }
 
 .playground-card {
   display: grid;
+  grid-template-rows: auto 1fr;
   gap: 22px;
   background: rgba(9, 13, 38, 0.85);
   border: 1px solid rgba(120, 147, 255, 0.16);
@@ -1007,7 +1061,7 @@ body.home-page a:focus {
 
 .playground-content {
   display: grid;
-  gap: 16px;
+  gap: 20px;
 }
 
 .playground-content p {
@@ -1059,6 +1113,10 @@ body.home-page a:focus {
     gap: 24px;
   }
 
+  .home-header .header-controls {
+    gap: 16px;
+  }
+
   .home-nav {
     gap: 18px;
     font-size: 0.9rem;
@@ -1090,6 +1148,15 @@ body.home-page a:focus {
     flex-wrap: wrap;
     align-items: center;
     gap: 12px;
+  }
+
+  .home-header .header-controls {
+    width: 100%;
+    gap: 12px;
+  }
+
+  .language-toggle {
+    order: 2;
   }
 
   .home-header .nav-toggle {

--- a/index.html
+++ b/index.html
@@ -17,16 +17,22 @@
   <header class="home-header">
     <div class="header-inner">
       <div class="brand">Hao Jin</div>
-      <nav class="home-nav" id="primary-navigation">
-        <a href="#top">Home</a>
-        <a href="#about">About</a>
-        <a href="#projects">Projects</a>
-        <a href="https://github.com/jhao" target="_blank" rel="noopener">GitHub</a>
-        <a href="mailto:hao.jin@live.cn">Contact</a>
-      </nav>
-      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Toggle navigation">
-        <span></span>
-      </button>
+      <div class="header-controls">
+        <nav class="home-nav" id="primary-navigation">
+          <a href="#top" data-i18n="nav.home">Home</a>
+          <a href="#about" data-i18n="nav.about">About</a>
+          <a href="#projects" data-i18n="nav.projects">Projects</a>
+          <a href="https://github.com/jhao" target="_blank" rel="noopener" data-i18n="nav.github">GitHub</a>
+          <a href="mailto:hao.jin@live.cn" data-i18n="nav.contact">Contact</a>
+        </nav>
+        <div class="language-toggle" role="group" aria-label="Select language" data-i18n-attr="aria-label:language.label">
+          <button type="button" class="language-button is-active" data-set-language="en" data-i18n="language.english">EN</button>
+          <button type="button" class="language-button" data-set-language="zh" data-i18n="language.chinese">中文</button>
+        </div>
+        <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Toggle navigation" data-i18n-attr="aria-label:nav.toggle">
+          <span></span>
+        </button>
+      </div>
     </div>
   </header>
 
@@ -34,12 +40,12 @@
     <section class="hero" id="top">
       <canvas id="space-canvas" aria-hidden="true"></canvas>
       <div class="hero-overlay">
-        <p class="tagline">Exploring ideas in code, design, and data</p>
-        <h1>Welcome to My Constellation</h1>
-        <p class="lead">Take a tour through a living star map inspired by Ursa Major and discover the projects and passions that guide my work.</p>
-        <a class="cta" href="#about">Discover more</a>
+        <p class="tagline" data-i18n="hero.tagline">Exploring ideas in code, design, and data</p>
+        <h1 data-i18n="hero.title">Welcome to My Constellation</h1>
+        <p class="lead" data-i18n="hero.lead">Take a tour through a living star map inspired by Ursa Major and discover the projects and passions that guide my work.</p>
+        <a class="cta" href="#about" data-i18n="hero.cta">Discover more</a>
       </div>
-      <button class="scroll-indicator" type="button" data-scroll-to="#about" aria-label="Scroll to about section">
+      <button class="scroll-indicator" type="button" data-scroll-to="#about" aria-label="Scroll to about section" data-i18n-attr="aria-label:hero.scroll">
         <span></span>
       </button>
     </section>
@@ -47,39 +53,39 @@
     <section class="profile" id="about">
       <div class="profile-wrapper">
         <div class="profile-intro">
-          <h2>About Hao</h2>
-          <p>
+          <h2 data-i18n="about.title">About Hao</h2>
+          <p data-i18n="about.paragraph1">
             I’m a builder who loves transforming complex ideas into delightful digital experiences. From backend services to interactive data
             visualizations, I enjoy navigating the entire stack and delivering work that feels both meaningful and elegant.
           </p>
-          <p>
+          <p data-i18n="about.paragraph2">
             When I’m not experimenting with new technologies, you can find me capturing the night sky through astrophotography or exploring the
             latest trends in human–computer interaction.
           </p>
         </div>
         <div class="info-grid">
           <div class="info-card">
-            <h3>Current Focus</h3>
+            <h3 data-i18n="info.focus.title">Current Focus</h3>
             <ul>
-              <li>Building resilient systems with Go &amp; Python</li>
-              <li>Crafting immersive data products</li>
-              <li>Designing human-centered developer tooling</li>
+              <li data-i18n="info.focus.item1">Building resilient systems with Go &amp; Python</li>
+              <li data-i18n="info.focus.item2">Crafting immersive data products</li>
+              <li data-i18n="info.focus.item3">Designing human-centered developer tooling</li>
             </ul>
           </div>
           <div class="info-card">
-            <h3>Selected Work</h3>
+            <h3 data-i18n="info.work.title">Selected Work</h3>
             <ul>
-              <li><a href="https://github.com/jhao">Open-source contributions on GitHub</a></li>
-              <li>Real-time monitoring dashboards</li>
-              <li>Interactive storytelling experiments</li>
+              <li><a href="https://github.com/jhao" data-i18n="info.work.item1">Open-source contributions on GitHub</a></li>
+              <li data-i18n="info.work.item2">Real-time monitoring dashboards</li>
+              <li data-i18n="info.work.item3">Interactive storytelling experiments</li>
             </ul>
           </div>
           <div class="info-card">
-            <h3>Let’s Connect</h3>
+            <h3 data-i18n="info.connect.title">Let’s Connect</h3>
             <ul>
-              <li><a href="mailto:hao.jin@live.cn">hao.jin@live.cn</a></li>
-              <li><a href="https://twitter.com/haojinhj">@haojinhj on Twitter</a></li>
-              <li><a href="https://www.haoj.in">www.haoj.in</a></li>
+              <li><a href="mailto:hao.jin@live.cn" data-i18n="info.connect.item1">hao.jin@live.cn</a></li>
+              <li><a href="https://twitter.com/haojinhj" data-i18n="info.connect.item2">@haojinhj on Twitter</a></li>
+              <li><a href="https://www.haoj.in" data-i18n="info.connect.item3">www.haoj.in</a></li>
             </ul>
           </div>
         </div>
@@ -89,25 +95,25 @@
     <section class="projects" id="projects">
       <div class="projects-wrapper">
         <div class="section-header">
-          <p class="eyebrow">Projects</p>
-          <h2>Explore My Recent Work</h2>
-          <p class="description">A snapshot of experiments, tools, and platforms I’m building to make product thinking, automation, and storytelling more tangible.</p>
+          <p class="eyebrow" data-i18n="projects.eyebrow">Projects</p>
+          <h2 data-i18n="projects.title">Explore My Recent Work</h2>
+          <p class="description" data-i18n="projects.description">A snapshot of experiments, tools, and platforms I’m building to make product thinking, automation, and storytelling more tangible.</p>
         </div>
         <div class="projects-grid">
           <article class="project-card">
             <div class="project-content">
               <h3>PM Universe</h3>
-              <p>A constellation of product management resources that visualizes frameworks, case studies, and tactics for easier exploration.</p>
+              <p data-i18n="projects.pmUniverse.description">A constellation of product management resources that visualizes frameworks, case studies, and tactics for easier exploration.</p>
             </div>
             <div class="project-links">
               <a href="https://github.com/jhao/pm-universe" target="_blank" rel="noopener">GitHub</a>
-              <a href="https://haoj.in/pm-universe" target="_blank" rel="noopener">Demo</a>
+              <a href="https://haoj.in/pm-universe" target="_blank" rel="noopener" data-i18n="projects.pmUniverse.demo">Demo</a>
             </div>
           </article>
           <article class="project-card">
             <div class="project-content">
               <h3>SignX</h3>
-              <p>A minimalist e-signature workflow focused on privacy, speed, and clarity for teams that need agreements without the friction.</p>
+              <p data-i18n="projects.signx.description">A minimalist e-signature workflow focused on privacy, speed, and clarity for teams that need agreements without the friction.</p>
             </div>
             <div class="project-links">
               <a href="https://github.com/jhao/SignX" target="_blank" rel="noopener">GitHub</a>
@@ -116,7 +122,7 @@
           <article class="project-card">
             <div class="project-content">
               <h3>Local Bookshelf</h3>
-              <p>A personal knowledge library that syncs local reading notes with the cloud while keeping discovery fast and delightful.</p>
+              <p data-i18n="projects.localBookshelf.description">A personal knowledge library that syncs local reading notes with the cloud while keeping discovery fast and delightful.</p>
             </div>
             <div class="project-links">
               <a href="https://github.com/jhao/local-bookshelf" target="_blank" rel="noopener">GitHub</a>
@@ -125,7 +131,7 @@
           <article class="project-card">
             <div class="project-content">
               <h3>Policy Monitor</h3>
-              <p>Automated policy tracking that watches regulatory updates and surfaces alerts tailored to the teams who need to react.</p>
+              <p data-i18n="projects.policyMonitor.description">Automated policy tracking that watches regulatory updates and surfaces alerts tailored to the teams who need to react.</p>
             </div>
             <div class="project-links">
               <a href="https://github.com/jhao/policy_monitor" target="_blank" rel="noopener">GitHub</a>
@@ -134,7 +140,7 @@
           <article class="project-card">
             <div class="project-content">
               <h3>Evaluation System</h3>
-              <p>A scoring and reporting engine that simplifies performance reviews with transparent rubrics and actionable insights.</p>
+              <p data-i18n="projects.evaluationSystem.description">A scoring and reporting engine that simplifies performance reviews with transparent rubrics and actionable insights.</p>
             </div>
             <div class="project-links">
               <a href="https://github.com/jhao/evaluation-system" target="_blank" rel="noopener">GitHub</a>
@@ -143,7 +149,7 @@
           <article class="project-card">
             <div class="project-content">
               <h3>Mermaid Editor</h3>
-              <p>An interactive editor for crafting Mermaid diagrams with instant previews and sharing-friendly exports.</p>
+              <p data-i18n="projects.mermaidEditor.description">An interactive editor for crafting Mermaid diagrams with instant previews and sharing-friendly exports.</p>
             </div>
             <div class="project-links">
               <a href="https://github.com/jhao/mermaid-editor" target="_blank" rel="noopener">GitHub</a>
@@ -156,35 +162,35 @@
     <section class="playground" id="playground">
       <div class="playground-wrapper">
         <div class="section-header">
-          <p class="eyebrow">Playground</p>
-          <h2>互动体验</h2>
-          <p class="description">两个纯前端的小宇宙，欢迎点击进入体验它们的节奏与情绪。</p>
+          <p class="eyebrow" data-i18n="playground.eyebrow">Playground</p>
+          <h2 data-i18n="playground.title">Interactive Experiences</h2>
+          <p class="description" data-i18n="playground.description">两个纯前端的小宇宙，欢迎点击进入体验它们的节奏与情绪。</p>
         </div>
-        <div class="playground-grid">
-          <article class="playground-card">
+        <div class="playground-grid" role="list">
+          <article class="playground-card" role="listitem">
             <div class="playground-header">
               <span class="playground-icon" aria-hidden="true">🪐</span>
               <div class="playground-meta">
-                <p class="playground-subtitle">沉浸式街机</p>
-                <h3>Cosmic Pong</h3>
+                <p class="playground-subtitle" data-i18n="playground.cosmic.subtitle">Casual Ping Pong Arcade</p>
+                <h3 data-i18n="playground.cosmic.title">Cosmic Pong</h3>
               </div>
             </div>
             <div class="playground-content">
-              <p>复古的乒乓球玩法与太空视觉结合，节奏逐渐升级，和 AI 对手比拼反应力。</p>
-              <a class="playground-link" href="https://haoj.in/Cosmic-Pong/" target="_blank" rel="noopener">前往体验</a>
+              <p data-i18n="playground.cosmic.description">复古的乒乓球玩法与太空视觉结合，节奏逐渐升级，和 AI 对手比拼反应力。</p>
+              <a class="playground-link" href="https://haoj.in/Cosmic-Pong/" target="_blank" rel="noopener" data-i18n="playground.cosmic.link">前往体验</a>
             </div>
           </article>
-          <article class="playground-card">
+          <article class="playground-card" role="listitem">
             <div class="playground-header">
               <span class="playground-icon" aria-hidden="true">🌳</span>
               <div class="playground-meta">
-                <p class="playground-subtitle">情绪手帐</p>
-                <h3>树洞之树</h3>
+                <p class="playground-subtitle" data-i18n="playground.tree.subtitle">Emotion Journal</p>
+                <h3 data-i18n="playground.tree.title">树洞之树</h3>
               </div>
             </div>
             <div class="playground-content">
-              <p>挑选一棵树洞，写下心声，与记录对话的界面共同沉淀一份专属于你的私密空间。</p>
-              <a class="playground-link" href="https://haoj.in/tree-hole/" target="_blank" rel="noopener">走进树洞</a>
+              <p data-i18n="playground.tree.description">挑选一棵树洞，写下心声，与记录对话的界面共同沉淀一份专属于你的私密空间。</p>
+              <a class="playground-link" href="https://haoj.in/tree-hole/" target="_blank" rel="noopener" data-i18n="playground.tree.link">走进树洞</a>
             </div>
           </article>
         </div>
@@ -193,7 +199,7 @@
   </main>
 
   <footer class="home-footer">
-    <p>© <span id="current-year"></span> Hao Jin. Crafted with curiosity and stardust.</p>
+    <p data-i18n="footer.note" data-i18n-html="true">© <span id="current-year"></span> Hao Jin. Crafted with curiosity and stardust.</p>
   </footer>
 
   <script type="importmap">

--- a/js/home.js
+++ b/js/home.js
@@ -48,3 +48,248 @@
     }
   });
 })();
+
+(function () {
+  const translations = {
+    en: {
+      'nav.home': 'Home',
+      'nav.about': 'About',
+      'nav.projects': 'Projects',
+      'nav.github': 'GitHub',
+      'nav.contact': 'Contact',
+      'nav.toggle': 'Toggle navigation',
+      'language.label': 'Select language',
+      'language.english': 'EN',
+      'language.chinese': '中文',
+      'hero.tagline': 'Exploring ideas in code, design, and data',
+      'hero.title': 'Welcome to My Constellation',
+      'hero.lead':
+        'Take a tour through a living star map inspired by Ursa Major and discover the projects and passions that guide my work.',
+      'hero.cta': 'Discover more',
+      'hero.scroll': 'Scroll to about section',
+      'about.title': 'About Hao',
+      'about.paragraph1':
+        'I’m a builder who loves transforming complex ideas into delightful digital experiences. From backend services to interactive data visualizations, I enjoy navigating the entire stack and delivering work that feels both meaningful and elegant.',
+      'about.paragraph2':
+        'When I’m not experimenting with new technologies, you can find me capturing the night sky through astrophotography or exploring the latest trends in human–computer interaction.',
+      'info.focus.title': 'Current Focus',
+      'info.focus.item1': 'Building resilient systems with Go & Python',
+      'info.focus.item2': 'Crafting immersive data products',
+      'info.focus.item3': 'Designing human-centered developer tooling',
+      'info.work.title': 'Selected Work',
+      'info.work.item1': 'Open-source contributions on GitHub',
+      'info.work.item2': 'Real-time monitoring dashboards',
+      'info.work.item3': 'Interactive storytelling experiments',
+      'info.connect.title': 'Let’s Connect',
+      'info.connect.item1': 'hao.jin@live.cn',
+      'info.connect.item2': '@haojinhj on Twitter',
+      'info.connect.item3': 'www.haoj.in',
+      'projects.eyebrow': 'Projects',
+      'projects.title': 'Explore My Recent Work',
+      'projects.description':
+        'A snapshot of experiments, tools, and platforms I’m building to make product thinking, automation, and storytelling more tangible.',
+      'projects.pmUniverse.description':
+        'A constellation of product management resources that visualizes frameworks, case studies, and tactics for easier exploration.',
+      'projects.pmUniverse.demo': 'Demo',
+      'projects.signx.description':
+        'A minimalist e-signature workflow focused on privacy, speed, and clarity for teams that need agreements without the friction.',
+      'projects.localBookshelf.description':
+        'A personal knowledge library that syncs local reading notes with the cloud while keeping discovery fast and delightful.',
+      'projects.policyMonitor.description':
+        'Automated policy tracking that watches regulatory updates and surfaces alerts tailored to the teams who need to react.',
+      'projects.evaluationSystem.description':
+        'A scoring and reporting engine that simplifies performance reviews with transparent rubrics and actionable insights.',
+      'projects.mermaidEditor.description':
+        'An interactive editor for crafting Mermaid diagrams with instant previews and sharing-friendly exports.',
+      'playground.eyebrow': 'Playground',
+      'playground.title': 'Interactive Experiences',
+      'playground.description': 'Two purely front-end micro universes—click to feel their rhythm and moods.',
+      'playground.cosmic.subtitle': 'Casual Ping Pong Arcade',
+      'playground.cosmic.title': 'Cosmic Pong',
+      'playground.cosmic.description':
+        'Classic pong mechanics meet cosmic visuals in a steadily accelerating duel against an AI challenger.',
+      'playground.cosmic.link': 'Play now',
+      'playground.tree.subtitle': 'Emotion Journal',
+      'playground.tree.title': 'Tree of Whispers',
+      'playground.tree.description':
+        'Choose a hollow in the tree, pour out your thoughts, and let a reflective interface guard your private space.',
+      'playground.tree.link': 'Enter the grove',
+      'footer.note': '© {{year}} Hao Jin. Crafted with curiosity and stardust.'
+    },
+    zh: {
+      'nav.home': '首页',
+      'nav.about': '关于',
+      'nav.projects': '项目',
+      'nav.github': 'GitHub',
+      'nav.contact': '联系',
+      'nav.toggle': '切换导航',
+      'language.label': '选择语言',
+      'language.english': 'EN',
+      'language.chinese': '中文',
+      'hero.tagline': '在代码、设计与数据中探索创意',
+      'hero.title': '欢迎来到我的星座地图',
+      'hero.lead': '沿着以大熊座为灵感的星图漫游，发现驱动我创作的项目与热情。',
+      'hero.cta': '了解更多',
+      'hero.scroll': '滚动至关于部分',
+      'about.title': '关于 Hao',
+      'about.paragraph1':
+        '我是一名热衷于把复杂想法化为迷人数字体验的创造者。从后端服务到交互式数据可视化，我享受掌控全栈，将作品打磨得有温度也有质感。',
+      'about.paragraph2': '当我不在尝试新技术时，我会沉醉于天文摄影捕捉夜空，或探索人机交互领域的最新趋势。',
+      'info.focus.title': '当前聚焦',
+      'info.focus.item1': '用 Go 与 Python 构建稳定系统',
+      'info.focus.item2': '打造沉浸式数据产品',
+      'info.focus.item3': '设计以人为本的开发者工具',
+      'info.work.title': '精选作品',
+      'info.work.item1': 'GitHub 上的开源贡献',
+      'info.work.item2': '实时监控看板',
+      'info.work.item3': '交互式叙事实验',
+      'info.connect.title': '保持联系',
+      'info.connect.item1': 'hao.jin@live.cn',
+      'info.connect.item2': 'Twitter 上的 @haojinhj',
+      'info.connect.item3': 'www.haoj.in',
+      'projects.eyebrow': '项目',
+      'projects.title': '探索我的近期作品',
+      'projects.description': '这些作品凝聚了我对产品思考、自动化与叙事表达的探索。',
+      'projects.pmUniverse.description':
+        '一个汇聚产品管理框架、案例与策略的资源星图，帮助你更轻松地检索知识。',
+      'projects.pmUniverse.demo': '在线体验',
+      'projects.signx.description':
+        '一款注重隐私、速度与清晰度的极简电子签约流程，让团队签署文档不再繁琐。',
+      'projects.localBookshelf.description': '个人知识书架，同步本地阅读笔记到云端，同时保持探索的速度与愉悦。',
+      'projects.policyMonitor.description': '自动化的政策追踪工具，实时关注监管更新，并推送给需要迅速响应的团队。',
+      'projects.evaluationSystem.description': '一套透明的评分与报告引擎，用清晰的量表和洞察简化绩效评估。',
+      'projects.mermaidEditor.description': '交互式 Mermaid 绘图编辑器，支持即时预览与友好的导出分享体验。',
+      'playground.eyebrow': '互动场',
+      'playground.title': '互动体验',
+      'playground.description': '两个纯前端的小宇宙，欢迎点击进入体验它们的节奏与情绪。',
+      'playground.cosmic.subtitle': '休闲乒乓桌球',
+      'playground.cosmic.title': 'Cosmic Pong',
+      'playground.cosmic.description': '复古的乒乓球玩法结合宇宙视觉，节奏逐步升级，与 AI 对手比拼反应力。',
+      'playground.cosmic.link': '前往体验',
+      'playground.tree.subtitle': '情绪手帐',
+      'playground.tree.title': '树洞之树',
+      'playground.tree.description': '挑选一处树洞写下心声，与对话式的界面一起沉淀专属于你的私密空间。',
+      'playground.tree.link': '走进树洞',
+      'footer.note': '© {{year}} Hao Jin。以好奇与星尘打造。'
+    }
+  };
+
+  const supportedLanguages = Object.keys(translations);
+  const fallbackLanguage = 'en';
+  const storageKey = 'preferred-language';
+  const htmlLangMap = {
+    en: 'en',
+    zh: 'zh-Hans'
+  };
+
+  const translatableElements = document.querySelectorAll('[data-i18n]');
+  const attributeElements = document.querySelectorAll('[data-i18n-attr]');
+  const languageButtons = document.querySelectorAll('[data-set-language]');
+  const htmlElement = document.documentElement;
+
+  const formatTranslation = (value) =>
+    value.replace(/{{(\w+)}}/g, (match, token) => {
+      if (token === 'year') {
+        return '<span id="current-year"></span>';
+      }
+      return match;
+    });
+
+  const refreshYear = () => {
+    const yearElement = document.getElementById('current-year');
+    if (yearElement) {
+      yearElement.textContent = new Date().getFullYear();
+    }
+  };
+
+  const updateActiveButtons = (language) => {
+    languageButtons.forEach((button) => {
+      const isActive = button.dataset.setLanguage === language;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  };
+
+  const applyLanguage = (language, { persist = true } = {}) => {
+    const targetLanguage = supportedLanguages.includes(language) ? language : fallbackLanguage;
+    const htmlLanguageCode = htmlLangMap[targetLanguage] || targetLanguage;
+    htmlElement.setAttribute('lang', htmlLanguageCode);
+
+    translatableElements.forEach((element) => {
+      const key = element.dataset.i18n;
+      if (!key) {
+        return;
+      }
+
+      const translation = translations[targetLanguage][key];
+      if (typeof translation === 'undefined') {
+        return;
+      }
+
+      if (element.dataset.i18nHtml === 'true') {
+        element.innerHTML = formatTranslation(translation);
+      } else {
+        element.textContent = translation;
+      }
+    });
+
+    attributeElements.forEach((element) => {
+      const mapping = element.dataset.i18nAttr;
+      if (!mapping) {
+        return;
+      }
+
+      mapping.split(',').forEach((entry) => {
+        const [attributeName, translationKey] = entry.split(':').map((part) => part && part.trim());
+        if (!attributeName || !translationKey) {
+          return;
+        }
+
+        const value = translations[targetLanguage][translationKey];
+        if (typeof value === 'undefined') {
+          return;
+        }
+
+        element.setAttribute(attributeName, value);
+      });
+    });
+
+    updateActiveButtons(targetLanguage);
+    refreshYear();
+
+    if (persist) {
+      try {
+        window.localStorage.setItem(storageKey, targetLanguage);
+      } catch (error) {
+        /* ignore persistence errors */
+      }
+    }
+  };
+
+  const resolveInitialLanguage = () => {
+    try {
+      const storedValue = window.localStorage.getItem(storageKey);
+      if (storedValue && supportedLanguages.includes(storedValue)) {
+        return storedValue;
+      }
+    } catch (error) {
+      /* ignore retrieval errors */
+    }
+
+    const userLanguage = navigator.language || (Array.isArray(navigator.languages) ? navigator.languages[0] : '');
+    if (typeof userLanguage === 'string' && userLanguage.toLowerCase().startsWith('zh')) {
+      return 'zh';
+    }
+
+    return fallbackLanguage;
+  };
+
+  languageButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const selectedLanguage = button.dataset.setLanguage;
+      applyLanguage(selectedLanguage);
+    });
+  });
+
+  applyLanguage(resolveInitialLanguage(), { persist: false });
+})();


### PR DESCRIPTION
## Summary
- add a language toggle to the header and annotate page content for translation
- implement bilingual copy management in `home.js` and refresh interactive playground naming
- polish playground card layout and styling for side-by-side presentation

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914442950988320a7a5060474e26a87)