### PR TITLE
Remove social preview image asset

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,12 +6,52 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Hao Jin | Home</title>
   <meta name="description" content="Welcome to Hao Jin's digital cosmos – explore my work, interests, and ways to connect." />
+  <meta name="keywords" content="Hao Jin, product strategy, software engineering, data visualization, digital experiences, portfolio">
+  <meta name="author" content="Hao Jin">
+  <meta name="robots" content="index, follow">
+  <meta name="theme-color" content="#0b0d18">
   <link rel="stylesheet" href="/css/main.css">
-  <link rel="canonical" href="http://yourdomain.com/">
-  <link rel="alternate" type="application/rss+xml" title="Home" href="http://yourdomain.com/feed.xml">
+  <link rel="canonical" href="https://www.haoj.in/">
+  <link rel="alternate" type="application/rss+xml" title="Home" href="https://www.haoj.in/feed.xml">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Hao Jin">
+  <meta property="og:title" content="Hao Jin | Digital Product &amp; Systems Builder">
+  <meta property="og:description" content="Explore Hao Jin's portfolio of product strategy, system design, and interactive experiments.">
+  <meta property="og:url" content="https://www.haoj.in/">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:locale:alternate" content="zh_CN">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Hao Jin | Digital Product &amp; Systems Builder">
+  <meta name="twitter:description" content="Discover Hao Jin's work across product strategy, engineering, and interactive storytelling.">
+  <meta name="twitter:creator" content="@haojinhj">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "Hao Jin",
+      "url": "https://www.haoj.in/",
+      "publisher": {
+        "@type": "Person",
+        "name": "Hao Jin",
+        "jobTitle": "Digital Product &amp; Systems Builder",
+        "email": "mailto:hao.jin@live.cn",
+        "sameAs": [
+          "https://github.com/jhao",
+          "https://www.haoj.in/",
+          "https://twitter.com/haojinhj"
+        ]
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.haoj.in/?s={search_term_string}",
+        "query-input": "required name=search_term_string"
+      },
+      "description": "Explore Hao Jin's portfolio of product strategy, system design, and interactive experiments."
+    }
+  </script>
 </head>
 <body class="home-page">
   <header class="home-header">


### PR DESCRIPTION
## Summary
- delete the `img/social-card.png` asset from the repository
- remove Open Graph and Twitter image tags that referenced the deleted asset on the homepage

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69144e11b6f08320bb43c4547a25d687)