### PR TITLE
Add Baidu analytics tracking to site pages

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -13,6 +13,15 @@
   <link rel="stylesheet" href="/css/main.css">
   <link rel="canonical" href="http://yourdomain.com/about/">
   <link rel="alternate" type="application/rss+xml" title="Home" href="http://yourdomain.com/feed.xml">
+  <script>
+  var _hmt = _hmt || [];
+  (function() {
+    var hm = document.createElement("script");
+    hm.src = "https://hm.baidu.com/hm.js?86213e9327b18cf9170d6fd6c5ba57ee";
+    var s = document.getElementsByTagName("script")[0]; 
+    s.parentNode.insertBefore(hm, s);
+  })();
+  </script>
 </head>
 
 

--- a/assessment/2016/09/20/Amazon-SDE-Assessment.html
+++ b/assessment/2016/09/20/Amazon-SDE-Assessment.html
@@ -12,6 +12,15 @@
   <link rel="stylesheet" href="/css/main.css">
   <link rel="canonical" href="http://haoj.in/assessment/2016/09/20/Amazon-SDE-Assessment.html">
   <link rel="alternate" type="application/rss+xml" title="Home" href="http://haoj.in/feed.xml">
+  <script>
+  var _hmt = _hmt || [];
+  (function() {
+    var hm = document.createElement("script");
+    hm.src = "https://hm.baidu.com/hm.js?86213e9327b18cf9170d6fd6c5ba57ee";
+    var s = document.getElementsByTagName("script")[0]; 
+    s.parentNode.insertBefore(hm, s);
+  })();
+  </script>
 </head>
 
 

--- a/index.html
+++ b/index.html
@@ -52,6 +52,15 @@
       "description": "Explore Hao Jin's portfolio of product strategy, system design, and interactive experiments."
     }
   </script>
+  <script>
+  var _hmt = _hmt || [];
+  (function() {
+    var hm = document.createElement("script");
+    hm.src = "https://hm.baidu.com/hm.js?86213e9327b18cf9170d6fd6c5ba57ee";
+    var s = document.getElementsByTagName("script")[0]; 
+    s.parentNode.insertBefore(hm, s);
+  })();
+  </script>
 </head>
 <body class="home-page">
   <header class="home-header">

--- a/jekyll/update/2016/02/05/welcome-to-jekyll.html
+++ b/jekyll/update/2016/02/05/welcome-to-jekyll.html
@@ -12,6 +12,15 @@
   <link rel="stylesheet" href="/css/main.css">
   <link rel="canonical" href="http://yourdomain.com/jekyll/update/2016/02/05/welcome-to-jekyll.html">
   <link rel="alternate" type="application/rss+xml" title="Home" href="http://yourdomain.com/feed.xml">
+  <script>
+  var _hmt = _hmt || [];
+  (function() {
+    var hm = document.createElement("script");
+    hm.src = "https://hm.baidu.com/hm.js?86213e9327b18cf9170d6fd6c5ba57ee";
+    var s = document.getElementsByTagName("script")[0]; 
+    s.parentNode.insertBefore(hm, s);
+  })();
+  </script>
 </head>
 
 


### PR DESCRIPTION
## Summary
- add Baidu analytics tracking script to all HTML pages to capture visit statistics

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198179acb08320861fad4b79ea373e)