### PR TITLE
Disable mouse wheel zoom on homepage starfield

### DIFF
--- a/js/starfield.js
+++ b/js/starfield.js
@@ -24,6 +24,7 @@ import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/exampl
 
   const controls = new OrbitControls(camera, canvas);
   controls.enableDamping = true;
+  controls.enableZoom = false;
   controls.enablePan = true;
   controls.minDistance = 30;
   controls.maxDistance = 260;


### PR DESCRIPTION
## Summary
- disable OrbitControls zoom handling for the homepage star map so mouse wheel scrolling only scrolls the page

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bcdc7aa448320ae4412d522a58a3d)