### PR TITLE
Add publications nav, bilingual copy updates, and light/dark theme toggle

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -574,6 +574,34 @@ body.home-page a:focus {
   box-shadow: 0 10px 20px rgba(6, 10, 31, 0.35);
 }
 
+.theme-toggle {
+  border: 1px solid rgba(191, 214, 255, 0.25);
+  border-radius: 999px;
+  background: rgba(4, 6, 18, 0.65);
+  color: rgba(214, 223, 255, 0.9);
+  padding: 8px 16px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 24px rgba(6, 10, 31, 0.28);
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus {
+  color: #ffffff;
+  background: rgba(4, 6, 18, 0.8);
+  border-color: rgba(191, 214, 255, 0.45);
+  outline: none;
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid rgba(197, 210, 255, 0.6);
+  outline-offset: 2px;
+}
+
 .nav-toggle {
   display: none;
   align-items: center;
@@ -1185,6 +1213,278 @@ body.home-page a:focus {
   text-transform: uppercase;
 }
 
+body.home-page.theme-light {
+  color: #1b2340;
+  background-color: #f5f7ff;
+}
+
+body.home-page.theme-light a {
+  color: #2b5fd6;
+}
+
+body.home-page.theme-light a:hover,
+body.home-page.theme-light a:focus {
+  color: #1b2b5a;
+}
+
+body.home-page.theme-light .home-header {
+  background: linear-gradient(180deg, rgba(245, 247, 255, 0.95) 0%, rgba(245, 247, 255, 0.7) 60%, rgba(245, 247, 255, 0) 100%);
+}
+
+body.home-page.theme-light .home-header .brand {
+  color: #1b2340;
+}
+
+body.home-page.theme-light .language-toggle {
+  border-color: rgba(43, 95, 214, 0.2);
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 12px 24px rgba(42, 56, 96, 0.12);
+}
+
+body.home-page.theme-light .language-button {
+  color: rgba(35, 48, 92, 0.8);
+}
+
+body.home-page.theme-light .language-button:hover,
+body.home-page.theme-light .language-button:focus {
+  color: #1b2340;
+}
+
+body.home-page.theme-light .language-button.is-active {
+  background: linear-gradient(135deg, #5a8eff 0%, #9bb8ff 100%);
+  color: #ffffff;
+  box-shadow: 0 10px 20px rgba(42, 56, 96, 0.18);
+}
+
+body.home-page.theme-light .theme-toggle {
+  border-color: rgba(43, 95, 214, 0.25);
+  background: rgba(255, 255, 255, 0.85);
+  color: rgba(35, 48, 92, 0.8);
+  box-shadow: 0 12px 24px rgba(42, 56, 96, 0.12);
+}
+
+body.home-page.theme-light .theme-toggle:hover,
+body.home-page.theme-light .theme-toggle:focus {
+  color: #1b2340;
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(43, 95, 214, 0.4);
+}
+
+body.home-page.theme-light .nav-toggle {
+  border-color: rgba(43, 95, 214, 0.25);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+body.home-page.theme-light .nav-toggle span,
+body.home-page.theme-light .nav-toggle::before,
+body.home-page.theme-light .nav-toggle::after {
+  background: #1b2340;
+}
+
+body.home-page.theme-light .hero::after {
+  background: radial-gradient(circle at 50% 40%, rgba(123, 168, 255, 0.35) 0%, rgba(240, 244, 255, 0.85) 55%, rgba(245, 247, 255, 0.95) 100%);
+}
+
+body.home-page.theme-light .hero-overlay {
+  color: #1b2340;
+}
+
+body.home-page.theme-light .hero-overlay .tagline {
+  color: rgba(64, 86, 160, 0.7);
+}
+
+body.home-page.theme-light .hero-overlay h1 {
+  color: #1a2040;
+}
+
+body.home-page.theme-light .hero-overlay .lead {
+  color: rgba(43, 58, 110, 0.85);
+}
+
+body.home-page.theme-light .cta {
+  color: #ffffff;
+  box-shadow: 0 12px 30px rgba(74, 112, 214, 0.25);
+}
+
+body.home-page.theme-light .cta:hover,
+body.home-page.theme-light .cta:focus {
+  color: #ffffff;
+  box-shadow: 0 16px 36px rgba(74, 112, 214, 0.35);
+}
+
+body.home-page.theme-light .scroll-indicator {
+  border-color: rgba(50, 74, 150, 0.4);
+}
+
+body.home-page.theme-light .scroll-indicator span {
+  background: rgba(50, 74, 150, 0.55);
+}
+
+body.home-page.theme-light .profile {
+  background: linear-gradient(180deg, rgba(243, 246, 255, 1) 0%, rgba(235, 240, 255, 1) 100%);
+}
+
+body.home-page.theme-light .profile::before {
+  opacity: 0.4;
+}
+
+body.home-page.theme-light .profile-intro p {
+  color: rgba(39, 52, 98, 0.8);
+}
+
+body.home-page.theme-light .info-card {
+  background: rgba(255, 255, 255, 0.9);
+  border-color: rgba(160, 182, 255, 0.35);
+  box-shadow: 0 20px 40px rgba(47, 65, 120, 0.12);
+}
+
+body.home-page.theme-light .info-card h3 {
+  color: #1b2340;
+}
+
+body.home-page.theme-light .info-card ul {
+  color: rgba(39, 52, 98, 0.75);
+}
+
+body.home-page.theme-light .info-card li::before {
+  color: rgba(88, 120, 214, 0.75);
+}
+
+body.home-page.theme-light .projects {
+  background: radial-gradient(circle at 20% 20%, rgba(122, 160, 255, 0.2), transparent 45%),
+    radial-gradient(circle at 80% 15%, rgba(160, 120, 255, 0.18), transparent 50%),
+    rgba(242, 246, 255, 0.95);
+}
+
+body.home-page.theme-light .projects::before {
+  opacity: 0.3;
+}
+
+body.home-page.theme-light .section-header .eyebrow {
+  color: rgba(64, 86, 160, 0.7);
+}
+
+body.home-page.theme-light .section-header h2 {
+  color: #1a2040;
+}
+
+body.home-page.theme-light .section-header .description {
+  color: rgba(39, 52, 98, 0.78);
+}
+
+body.home-page.theme-light .projects-column-header h3 {
+  color: #1a2040;
+}
+
+body.home-page.theme-light .projects-column-header p {
+  color: rgba(39, 52, 98, 0.7);
+}
+
+body.home-page.theme-light .project-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(160, 182, 255, 0.3);
+  box-shadow: 0 22px 40px rgba(47, 65, 120, 0.12);
+}
+
+body.home-page.theme-light .project-content h3 {
+  color: #1b2340;
+}
+
+body.home-page.theme-light .project-content p {
+  color: rgba(39, 52, 98, 0.75);
+}
+
+body.home-page.theme-light .project-links a {
+  border-color: rgba(110, 146, 240, 0.55);
+  color: rgba(32, 60, 132, 0.9);
+}
+
+body.home-page.theme-light .project-links a:hover,
+body.home-page.theme-light .project-links a:focus {
+  color: #ffffff;
+}
+
+body.home-page.theme-light .playground {
+  background: linear-gradient(180deg, rgba(240, 244, 255, 1) 0%, rgba(233, 239, 255, 1) 100%);
+}
+
+body.home-page.theme-light .playground::before {
+  opacity: 0.35;
+}
+
+body.home-page.theme-light .playground-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(160, 182, 255, 0.3);
+  box-shadow: 0 22px 40px rgba(47, 65, 120, 0.12);
+}
+
+body.home-page.theme-light .playground-header {
+  background: linear-gradient(135deg, rgba(110, 146, 240, 0.2) 0%, rgba(164, 142, 255, 0.2) 100%);
+  border-color: rgba(120, 150, 240, 0.25);
+}
+
+body.home-page.theme-light .playground-icon {
+  background: rgba(235, 241, 255, 0.85);
+  box-shadow: 0 10px 24px rgba(47, 65, 120, 0.12);
+}
+
+body.home-page.theme-light .playground-meta h3 {
+  color: #1b2340;
+}
+
+body.home-page.theme-light .playground-subtitle {
+  color: rgba(64, 86, 160, 0.7);
+}
+
+body.home-page.theme-light .playground-content p {
+  color: rgba(39, 52, 98, 0.78);
+}
+
+body.home-page.theme-light .playground-link {
+  border-color: rgba(110, 146, 240, 0.55);
+  color: rgba(32, 60, 132, 0.9);
+}
+
+body.home-page.theme-light .playground-link:hover,
+body.home-page.theme-light .playground-link:focus {
+  color: #ffffff;
+}
+
+body.home-page.theme-light .publications {
+  background: radial-gradient(circle at 10% 20%, rgba(122, 160, 255, 0.2), transparent 45%),
+    radial-gradient(circle at 85% 70%, rgba(160, 120, 255, 0.18), transparent 55%),
+    rgba(242, 246, 255, 0.95);
+}
+
+body.home-page.theme-light .publication-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(160, 182, 255, 0.3);
+  box-shadow: 0 22px 40px rgba(47, 65, 120, 0.12);
+}
+
+body.home-page.theme-light .publication-content {
+  color: rgba(39, 52, 98, 0.78);
+}
+
+body.home-page.theme-light .publication-content h3 {
+  color: #1b2340;
+}
+
+body.home-page.theme-light .home-footer {
+  background: #eef2ff;
+  color: rgba(39, 52, 98, 0.6);
+}
+
+body.home-page.theme-light.nav-enhanced .home-nav {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(160, 182, 255, 0.3);
+  box-shadow: 0 16px 30px rgba(47, 65, 120, 0.12);
+}
+
+body.home-page.theme-light.nav-enhanced .home-nav a {
+  border-bottom-color: rgba(160, 182, 255, 0.2);
+}
+
 @media (max-width: 900px) {
   .home-header {
     padding: 20px clamp(18px, 7vw, 88px);
@@ -1238,6 +1538,10 @@ body.home-page a:focus {
 
   .language-toggle {
     order: 2;
+  }
+
+  .theme-toggle {
+    order: 3;
   }
 
   .home-header .nav-toggle {

--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
           <a href="#top" data-i18n="nav.home">Home</a>
           <a href="#about" data-i18n="nav.about">About</a>
           <a href="#projects" data-i18n="nav.projects">Projects</a>
+          <a href="#publications" data-i18n="nav.publications">Publications</a>
           <a href="https://github.com/jhao" target="_blank" rel="noopener" data-i18n="nav.github">GitHub</a>
           <a href="mailto:hao.jin@live.cn" data-i18n="nav.contact">Contact</a>
         </nav>
@@ -78,6 +79,9 @@
           <button type="button" class="language-button is-active" data-set-language="en" data-i18n="language.english">EN</button>
           <button type="button" class="language-button" data-set-language="zh" data-i18n="language.chinese">中文</button>
         </div>
+        <button class="theme-toggle" type="button" data-theme-toggle data-i18n-attr="aria-label:theme.toggle">
+          <span data-theme-label>Light</span>
+        </button>
         <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Toggle navigation" data-i18n-attr="aria-label:nav.toggle">
           <span></span>
         </button>
@@ -156,7 +160,7 @@
           <div class="projects-column">
             <div class="projects-column-header">
               <h3 data-i18n="projects.column.products">Platforms &amp; Products</h3>
-              <p data-i18n="projects.column.products.description">核心产品与系统能力的集锦，从流程型平台到可视化体验。</p>
+              <p data-i18n="projects.column.products.description">A curated lineup of core platforms and system capabilities, from workflow engines to visual experiences.</p>
             </div>
             <div class="projects-grid">
               <article class="project-card">
@@ -412,7 +416,7 @@
   </main>
 
   <footer class="home-footer">
-    <p data-i18n="footer.note" data-i18n-html="true">© <span id="current-year"></span> Hao Jin. Crafted with curiosity and stardust.</p>
+    <p data-i18n="footer.note" data-i18n-html="true">© <span id="current-year"></span> Hao Jin. Crafted with curiosity, code, and constellations.</p>
   </footer>
 
   <script type="importmap">

--- a/js/home.js
+++ b/js/home.js
@@ -55,12 +55,16 @@
       'nav.home': 'Home',
       'nav.about': 'About',
       'nav.projects': 'Works',
+      'nav.publications': 'Publications',
       'nav.github': 'GitHub',
       'nav.contact': 'Contact',
       'nav.toggle': 'Toggle navigation',
       'language.label': 'Select language',
       'language.english': 'EN',
       'language.chinese': '中文',
+      'theme.toggle': 'Toggle theme',
+      'theme.toggle.light': 'Light',
+      'theme.toggle.dark': 'Dark',
       'hero.tagline': 'Exploring ideas in code, design, and data',
       'hero.title': 'Digital & Intelligent Panorama Solutions',
       'hero.lead':
@@ -92,6 +96,9 @@
       'projects.title': 'Explore My Recent Work',
       'projects.description':
         'A snapshot of experiments, tools, and platforms I’m building to make product thinking, automation, and storytelling more tangible.',
+      'projects.column.products': 'Platforms & Products',
+      'projects.column.products.description':
+        'A curated lineup of core platforms and system capabilities, from workflow engines to visual experiences.',
       'projects.pmUniverse.description':
         'A constellation of product management resources that visualizes frameworks, case studies, and tactics for easier exploration.',
       'projects.pmUniverse.demo': 'Demo',
@@ -159,18 +166,22 @@
       'toolbox.plank.title': 'Plank Master Pro',
       'toolbox.plank.description': 'Track plank sessions with timing and streak-focused records.',
       'toolbox.plank.link': 'Start timer',
-      'footer.note': '© {{year}} Hao Jin. Crafted with curiosity and stardust.'
+      'footer.note': '© {{year}} Hao Jin. Crafted with curiosity, code, and constellations.'
     },
     zh: {
       'nav.home': '首页',
       'nav.about': '关于',
       'nav.projects': '作品',
+      'nav.publications': '著作',
       'nav.github': 'GitHub',
       'nav.contact': '联系',
       'nav.toggle': '切换导航',
       'language.label': '选择语言',
       'language.english': 'EN',
       'language.chinese': '中文',
+      'theme.toggle': '切换配色模式',
+      'theme.toggle.light': '明亮',
+      'theme.toggle.dark': '深色',
       'hero.tagline': '在代码、设计与数据中探索创意',
       'hero.title': '数字与智能化全景解决方案',
       'hero.lead': '沿着数字与智能化全景路径前行，探索企业业务赋能所需的架构实践、AI 应用与产品落地。',
@@ -199,6 +210,8 @@
       'projects.eyebrow': '项目',
       'projects.title': '探索我的近期作品',
       'projects.description': '这些作品凝聚了我对产品思考、自动化与叙事表达的探索。',
+      'projects.column.products': '平台与产品',
+      'projects.column.products.description': '核心产品与系统能力的集锦，从流程型平台到可视化体验。',
       'projects.pmUniverse.description':
         '一个汇聚产品管理框架、案例与策略的资源星图，帮助你更轻松地检索知识。',
       'projects.pmUniverse.demo': '在线体验',
@@ -209,7 +222,7 @@
       'projects.evaluationSystem.description': '一套透明的评分与报告引擎，用清晰的量表和洞察简化绩效评估。',
       'projects.mermaidEditor.description': '交互式 Mermaid 绘图编辑器，支持即时预览与友好的导出分享体验。',
       'playground.eyebrow': '互动场',
-      'playground.title': '互动体验',
+      'playground.title': '一些应用与小系统',
       'playground.description': '两个纯前端的小宇宙，欢迎点击进入体验它们的节奏与情绪。',
       'playground.cosmic.subtitle': '休闲乒乓桌球',
       'playground.cosmic.title': 'Cosmic Pong',
@@ -256,7 +269,7 @@
       'toolbox.plank.title': 'Plank Master Pro',
       'toolbox.plank.description': '记录平板支撑训练时长与节奏，轻松保持锻炼习惯。',
       'toolbox.plank.link': '开启计时',
-      'footer.note': '© {{year}} Hao Jin。以好奇与星尘打造。'
+      'footer.note': '© {{year}} Hao Jin。以好奇、代码与星图点亮。'
     }
   };
 
@@ -271,7 +284,9 @@
   const translatableElements = document.querySelectorAll('[data-i18n]');
   const attributeElements = document.querySelectorAll('[data-i18n-attr]');
   const languageButtons = document.querySelectorAll('[data-set-language]');
+  const themeToggle = document.querySelector('[data-theme-toggle]');
   const htmlElement = document.documentElement;
+  const bodyElement = document.body;
 
   const formatTranslation = (value) =>
     value.replace(/{{(\w+)}}/g, (match, token) => {
@@ -296,9 +311,12 @@
     });
   };
 
+  let activeLanguage = fallbackLanguage;
+
   const applyLanguage = (language, { persist = true } = {}) => {
     const targetLanguage = supportedLanguages.includes(language) ? language : fallbackLanguage;
     const htmlLanguageCode = htmlLangMap[targetLanguage] || targetLanguage;
+    activeLanguage = targetLanguage;
     htmlElement.setAttribute('lang', htmlLanguageCode);
 
     translatableElements.forEach((element) => {
@@ -341,6 +359,7 @@
     });
 
     updateActiveButtons(targetLanguage);
+    updateThemeLabel();
     refreshYear();
 
     if (persist) {
@@ -370,6 +389,65 @@
     return fallbackLanguage;
   };
 
+  const themeStorageKey = 'preferred-theme';
+  const themeClass = 'theme-light';
+  const supportedThemes = ['light', 'dark'];
+  let activeTheme = 'dark';
+
+  const resolveInitialTheme = () => {
+    try {
+      const storedTheme = window.localStorage.getItem(themeStorageKey);
+      if (storedTheme && supportedThemes.includes(storedTheme)) {
+        return storedTheme;
+      }
+    } catch (error) {
+      /* ignore retrieval errors */
+    }
+
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+      return 'light';
+    }
+
+    return 'dark';
+  };
+
+  const updateThemeLabel = () => {
+    if (!themeToggle) {
+      return;
+    }
+
+    const labelKey = activeTheme === 'light' ? 'theme.toggle.dark' : 'theme.toggle.light';
+    const label = translations[activeLanguage][labelKey] || labelKey;
+    const labelElement = themeToggle.querySelector('[data-theme-label]');
+    if (labelElement) {
+      labelElement.textContent = label;
+    } else {
+      themeToggle.textContent = label;
+    }
+
+    themeToggle.setAttribute('aria-pressed', activeTheme === 'light' ? 'true' : 'false');
+  };
+
+  const applyTheme = (theme, { persist = true } = {}) => {
+    const resolvedTheme = supportedThemes.includes(theme) ? theme : 'dark';
+    activeTheme = resolvedTheme;
+
+    if (bodyElement) {
+      bodyElement.classList.toggle(themeClass, resolvedTheme === 'light');
+      bodyElement.dataset.theme = resolvedTheme;
+    }
+
+    updateThemeLabel();
+
+    if (persist) {
+      try {
+        window.localStorage.setItem(themeStorageKey, resolvedTheme);
+      } catch (error) {
+        /* ignore persistence errors */
+      }
+    }
+  };
+
   languageButtons.forEach((button) => {
     button.addEventListener('click', () => {
       const selectedLanguage = button.dataset.setLanguage;
@@ -377,5 +455,13 @@
     });
   });
 
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const nextTheme = activeTheme === 'light' ? 'dark' : 'light';
+      applyTheme(nextTheme);
+    });
+  }
+
+  applyTheme(resolveInitialTheme(), { persist: false });
   applyLanguage(resolveInitialLanguage(), { persist: false });
 })();


### PR DESCRIPTION
### Motivation
- Surface the existing Publications section in the top navigation so it is discoverable from the header.
- Replace the footer line with a phrase that better echoes the site tone and the updated copy.
- Provide a site-wide light/dark mode and localizable UI so visitors can switch appearance and language consistently.

### Description
- Added a Publications link to the header navigation and a theme toggle button (`data-theme-toggle`) to the header in `index.html`.
- Introduced light/dark theme support by toggling a `theme-light` class on `body` and persisting the selection to `localStorage` in `js/home.js`, plus a dynamic localized label (`data-theme-label`).
- Extended the translation bundle in `js/home.js` to include `nav.publications`, `projects.column.products` and theme labels, and renamed the Chinese `playground.title` to match the requested copy change.
- Implemented comprehensive light-mode styles in `css/main.css` that mirror homepage sections (header, hero, profile, projects, playground, publications, footer) and ensured responsive ordering of the theme toggle.

### Testing
- Launched a local HTTP server (`python -m http.server 8000`) and verified the homepage loads successfully.
- Ran an automated Playwright script that opened the page, toggled the theme control, and produced a full-page screenshot (`artifacts/home-light.png`), which completed without error.
- Changes were staged and committed; no other automated tests were configured for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69758e5794848320af199a4c1deb627d)