### PR TITLE
Refine light theme navigation color pairing

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1476,13 +1476,19 @@ body.home-page.theme-light .home-footer {
 }
 
 body.home-page.theme-light.nav-enhanced .home-nav {
-  background: rgba(255, 255, 255, 0.95);
-  border-color: rgba(160, 182, 255, 0.3);
-  box-shadow: 0 16px 30px rgba(47, 65, 120, 0.12);
+  background: rgba(255, 255, 255, 0.96);
+  border-color: rgba(140, 166, 235, 0.34);
+  box-shadow: 0 16px 30px rgba(40, 58, 112, 0.14);
 }
 
 body.home-page.theme-light.nav-enhanced .home-nav a {
-  border-bottom-color: rgba(160, 182, 255, 0.2);
+  color: #263a78;
+  border-bottom-color: rgba(140, 166, 235, 0.26);
+}
+
+body.home-page.theme-light.nav-enhanced .home-nav a:hover,
+body.home-page.theme-light.nav-enhanced .home-nav a:focus {
+  color: #17244e;
 }
 
 @media (max-width: 900px) {
@@ -1580,6 +1586,24 @@ body.home-page.theme-light.nav-enhanced .home-nav a {
   body.nav-enhanced .home-nav.is-open {
     padding: 12px clamp(18px, 8vw, 80px) 20px;
     max-height: 320px;
+  }
+
+  body.home-page.theme-light.nav-enhanced .home-nav {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(244, 249, 255, 0.96) 100%);
+    border-color: rgba(134, 165, 238, 0.34);
+    box-shadow: 0 18px 34px rgba(40, 58, 112, 0.16);
+  }
+
+  body.home-page.theme-light.nav-enhanced .home-nav a {
+    color: #2a417f;
+    border-bottom-color: rgba(134, 165, 238, 0.3);
+    background: transparent;
+  }
+
+  body.home-page.theme-light.nav-enhanced .home-nav a:hover,
+  body.home-page.theme-light.nav-enhanced .home-nav a:focus {
+    color: #182a5a;
+    background: rgba(219, 232, 255, 0.58);
   }
 
   body.nav-enhanced .nav-toggle {


### PR DESCRIPTION
### Motivation
- The light theme's navigation (especially when `nav-enhanced`) had high-contrast/competing background and text colors that made menu items uncomfortable to read, so the color pairing was tuned for improved harmony and legibility.

### Description
- Updated `css/main.css` to soften the `body.home-page.theme-light.nav-enhanced .home-nav` container by adjusting background opacity, `border-color`, and `box-shadow` to a more harmonious palette.
- Adjusted menu link text and divider colors and added explicit `:hover`/`:focus` text colors for `body.home-page.theme-light.nav-enhanced .home-nav a` to improve readability and interaction affordance.
- Added mobile-specific (`@media (max-width:640px)`) light-theme rules to provide a subtle gradient background, refined border/shadow, and a gentle hover/focus background for expanded mobile menus.
- Changes are scoped to navigation styling in `css/main.css` and do not affect other theme areas.

### Testing
- Ran `git diff -- css/main.css` and inspected the diff to verify the intended edits (succeeded).
- Committed the changes with `git commit` to record the update (succeeded).
- Attempted automated visual verification with a Playwright screenshot run, but the page could not be loaded in the test environment (`ERR_EMPTY_RESPONSE` / `ERR_FILE_NOT_FOUND`) so the visual check failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a107311a788320a30467ed442e979a)