### PR TITLE
Remove light nav-enhanced .home-nav container overrides

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1475,12 +1475,6 @@ body.home-page.theme-light .home-footer {
   color: rgba(39, 52, 98, 0.6);
 }
 
-body.home-page.theme-light.nav-enhanced .home-nav {
-  background: rgba(255, 255, 255, 0.96);
-  border-color: rgba(140, 166, 235, 0.34);
-  box-shadow: 0 16px 30px rgba(40, 58, 112, 0.14);
-}
-
 body.home-page.theme-light.nav-enhanced .home-nav a {
   color: #263a78;
   border-bottom-color: rgba(140, 166, 235, 0.26);
@@ -1586,12 +1580,6 @@ body.home-page.theme-light.nav-enhanced .home-nav a:focus {
   body.nav-enhanced .home-nav.is-open {
     padding: 12px clamp(18px, 8vw, 80px) 20px;
     max-height: 320px;
-  }
-
-  body.home-page.theme-light.nav-enhanced .home-nav {
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(244, 249, 255, 0.96) 100%);
-    border-color: rgba(134, 165, 238, 0.34);
-    box-shadow: 0 18px 34px rgba(40, 58, 112, 0.16);
   }
 
   body.home-page.theme-light.nav-enhanced .home-nav a {


### PR DESCRIPTION
### Motivation
- The `body.home-page.theme-light.nav-enhanced .home-nav` container overrides were forcing a light-themed container appearance that conflicted with the base `.home-nav` layout; removing them lets the common nav container styles apply while preserving link color rules.

### Description
- Removed the `body.home-page.theme-light.nav-enhanced .home-nav` rule block from the desktop section in `css/main.css` and removed the duplicated container override inside the `@media (max-width: 640px)` mobile query, keeping the link color and hover/focus rules intact.

### Testing
- Reviewed the CSS diff to confirm only the targeted container override blocks in `css/main.css` were removed and no other selectors were modified, which succeeded.
- Served the site with `python3 -m http.server 4173` and captured a full-page screenshot with Playwright at `http://127.0.0.1:4173/index.html` for visual verification, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a15727f7308320a7bc02e235ab82ea)